### PR TITLE
Update DFM for non-std SSL port event handler

### DIFF
--- a/HTTP/SSL Server/Forms/MainForm.dfm
+++ b/HTTP/SSL Server/Forms/MainForm.dfm
@@ -241,6 +241,7 @@ object frmMain: TfrmMain
     OnDisconnect = ServerDisconnect
     OnException = ServerException
     Scheduler = IdSchedulerOfThreadDefault1
+    OnQuerySSLPort = ServerQuerySSLPort
     OnCommandGet = ServerCommandGet
     Top = 200
   end


### PR DESCRIPTION
Add event handler to cater for a non-standard SSL port. Current Indy code only allows port 443 to be used for an SSL connection.  Current Indy code was updated to remove a bug that allowed SSL on any port without the use of this event handler.